### PR TITLE
Enhance visuals and descriptions

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,5 +1,7 @@
 /* Custom styles for the Energetic Blueprint */
 
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Open+Sans:wght@400;600&display=swap');
+
 :root {
     --bs-primary: #FFA500;
     --bs-info: #FFA500;
@@ -13,7 +15,7 @@ body {
     background-image: linear-gradient(rgba(0,0,0,0.7), rgba(0,0,0,0.7)), url('https://images.unsplash.com/photo-1444703686981-a3abbc4d4fe3?auto=format&fit=crop&w=1950&q=80');
     background-size: cover;
     background-attachment: fixed;
-    font-family: Helvetica, Arial, sans-serif;
+    font-family: 'Open Sans', sans-serif;
     color: #ffffff;
     min-height: 100vh;
 }
@@ -26,9 +28,14 @@ body {
 header h1 {
     font-size: 2.5rem;
     font-weight: 700;
+    font-family: 'Cinzel', serif;
     color: var(--bs-primary);
     text-shadow: 0 0 10px var(--bs-primary), 0 0 20px var(--bs-primary);
     margin-bottom: 0.5rem;
+}
+
+h2, h3, h4, h5, h6 {
+    font-family: 'Cinzel', serif;
 }
 
 header .lead {
@@ -58,6 +65,17 @@ header .lead {
 
 .card-header {
     border-bottom: 2px solid rgba(255, 165, 0, 0.4);
+    font-family: 'Cinzel', serif;
+}
+
+.ascendant-header, .planetary-header {
+    background-color: #f5f5f5 !important;
+    color: var(--bs-primary) !important;
+}
+
+.ascendant-section, .planetary-section {
+    background-color: #f5f5f5;
+    color: #333;
 }
 
 .card-body {
@@ -236,6 +254,7 @@ header .lead {
     font-weight: 600;
     font-size: 1.1rem;
     padding: 0.75rem 1rem;
+    font-family: 'Cinzel', serif;
     color: var(--bs-primary);
     text-shadow: 0 0 5px var(--bs-primary);
 }
@@ -260,7 +279,21 @@ header .lead {
     font-weight: 600;
     font-size: 1.1rem;
     padding: 0.75rem 1rem;
+    font-family: 'Cinzel', serif;
 }
+
+.house-card:nth-child(1) .card-header { color: hsl(240,60%,70%); }
+.house-card:nth-child(2) .card-header { color: hsl(220,60%,70%); }
+.house-card:nth-child(3) .card-header { color: hsl(200,60%,70%); }
+.house-card:nth-child(4) .card-header { color: hsl(180,60%,70%); }
+.house-card:nth-child(5) .card-header { color: hsl(160,60%,70%); }
+.house-card:nth-child(6) .card-header { color: hsl(140,60%,70%); }
+.house-card:nth-child(7) .card-header { color: hsl(120,60%,70%); }
+.house-card:nth-child(8) .card-header { color: hsl(100,60%,70%); }
+.house-card:nth-child(9) .card-header { color: hsl(80,60%,70%); }
+.house-card:nth-child(10) .card-header { color: hsl(60,60%,70%); }
+.house-card:nth-child(11) .card-header { color: hsl(40,60%,70%); }
+.house-card:nth-child(12) .card-header { color: hsl(20,60%,70%); }
 
 /* Flash messages */
 .alert-container {
@@ -277,19 +310,22 @@ header .lead {
     border: none;
 }
 
-/* Zodiac sign colors - improved for better contrast */
-.sign-aries { color: #FF6B6B; } /* Bright red */
-.sign-taurus { color: #A0D468; } /* Soft green */
-.sign-gemini { color: #FFCE54; } /* Bright yellow */
-.sign-cancer { color: #5AD3D1; } /* Light teal */
-.sign-leo { color: #FC9D5D; } /* Bright orange */
-.sign-virgo { color: #8CC152; } /* Lime green */
-.sign-libra { color: #EC87C0; } /* Soft pink */
-.sign-scorpio { color: #FFA500; } /* Purple */
-.sign-sagittarius { color: #FFA500; } /* Sky blue */
-.sign-capricorn { color: #D770AD; } /* Magenta */
-.sign-aquarius { color: #FFA500; } /* Blue */
-.sign-pisces { color: #FFA500; } /* Lavender */
+/* Zodiac sign colors by element */
+.sign-aries { color: #FF8C00; font-family: 'Cinzel', serif; }
+.sign-leo { color: #FF7043; font-family: 'Cinzel', serif; }
+.sign-sagittarius { color: #FF6B6B; font-family: 'Cinzel', serif; }
+
+.sign-taurus { color: #556B2F; font-family: 'Cinzel', serif; }
+.sign-virgo { color: #8FBC8F; font-family: 'Cinzel', serif; }
+.sign-capricorn { color: #2E8B57; font-family: 'Cinzel', serif; }
+
+.sign-gemini { color: #87CEFA; font-family: 'Cinzel', serif; }
+.sign-libra { color: #ADD8E6; font-family: 'Cinzel', serif; }
+.sign-aquarius { color: #B0C4DE; font-family: 'Cinzel', serif; }
+
+.sign-cancer { color: #4169E1; font-family: 'Cinzel', serif; }
+.sign-scorpio { color: #6A5ACD; font-family: 'Cinzel', serif; }
+.sign-pisces { color: #8A2BE2; font-family: 'Cinzel', serif; }
 
 /* Footer styling */
 footer {
@@ -306,6 +342,7 @@ footer .text-muted {
 @media (max-width: 768px) {
     header h1 {
         font-size: 2rem;
+        font-family: 'Cinzel', serif;
     }
     
     .chart-container {

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,9 @@
     
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://cdn.replit.com/agent/bootstrap-agent-dark-theme.min.css">
+
+    <!-- Google Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
     
     <!-- Custom CSS -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">

--- a/templates/result.html
+++ b/templates/result.html
@@ -7,6 +7,9 @@
     
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://cdn.replit.com/agent/bootstrap-agent-dark-theme.min.css">
+
+    <!-- Google Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
     
     <!-- Custom CSS -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
@@ -46,8 +49,8 @@
         
         <!-- Ascendant Section -->
         {% if ascendant %}
-        <div class="card mb-4">
-            <div class="card-header bg-primary text-white">
+        <div class="card mb-4 ascendant-section">
+            <div class="card-header ascendant-header">
                 <div class="d-flex justify-content-between align-items-center">
                     <h3 class="mb-0">Ascendant (Lagna)</h3>
                     <span class="badge bg-info" data-bs-toggle="tooltip" title="Calculated using Skyfield precision astronomical algorithms">
@@ -71,8 +74,8 @@
         {% endif %}
 
         <!-- Planets Section -->
-        <div class="card mb-4">
-            <div class="card-header bg-primary text-white">
+        <div class="card mb-4 planetary-section">
+            <div class="card-header planetary-header">
                 <h3 class="mb-0">Planetary Positions</h3>
             </div>
             <div class="card-body">
@@ -110,36 +113,6 @@
             </div>
         </div>
         
-        <!-- House Cusps Section -->
-        <div class="card mb-4">
-            <div class="card-header bg-secondary text-white">
-                <h3 class="mb-0">House Cusps (Whole Sign System)</h3>
-            </div>
-            <div class="card-body">
-                <p class="mb-4">
-                    Below are the house cusps based on the Whole Sign system, where the sign containing your Ascendant becomes the 1st house,
-                    and each subsequent sign becomes the next house. Each house represents a specific area of life.
-                </p>
-                
-                <div class="row row-cols-1 row-cols-md-3 g-4">
-                    {% for house in houses %}
-                    <div class="col">
-                        <div class="card house-card h-100">
-                            <div class="card-header bg-dark">
-                                House {{ house.house }}: <span class="sign-{{ house.sign.lower() }}">{{ house.sign }}</span>
-                            </div>
-                            <div class="card-body">
-                                <p class="card-text">
-                                    {{ house.meaning }}
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                    {% endfor %}
-                </div>
-            </div>
-        </div>
-        
         <!-- Planet Descriptions Section -->
         <div class="card mb-4">
             <div class="card-header bg-secondary text-white">
@@ -173,6 +146,36 @@
                                 
                                 <p class="card-text">
                                     {{ planet.description }}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+
+        <!-- House Cusps Section -->
+        <div class="card mb-4">
+            <div class="card-header bg-secondary text-white">
+                <h3 class="mb-0">House Cusps</h3>
+            </div>
+            <div class="card-body">
+                <p class="mb-4">
+                    Below are the house cusps based on the Whole Sign system, where the sign containing your Ascendant becomes the 1st house,
+                    and each subsequent sign becomes the next house. Each house represents a specific area of life.
+                </p>
+
+                <div class="row row-cols-1 row-cols-md-3 g-4">
+                    {% for house in houses %}
+                    <div class="col">
+                        <div class="card house-card h-100">
+                            <div class="card-header bg-dark">
+                                House {{ house.house }}: <span class="sign-{{ house.sign.lower() }}">{{ house.sign }}</span>
+                            </div>
+                            <div class="card-body">
+                                <p class="card-text">
+                                    {{ house.meaning }}
                                 </p>
                             </div>
                         </div>

--- a/utils/astrology.py
+++ b/utils/astrology.py
@@ -245,16 +245,16 @@ def get_house_meanings():
     Return a dictionary of house numbers and their astrological meanings.
     """
     return {
-        1: "Self, physical body, personality, appearance, life approach",
-        2: "Possessions, values, money, resources, self-worth",
-        3: "Communication, siblings, short trips, early education, neighbors",
-        4: "Home, family, roots, real estate, emotional foundation",
-        5: "Creativity, romance, children, pleasure, self-expression",
-        6: "Health, daily routines, service, work environment, skills",
-        7: "Partnerships, marriage, contracts, open enemies, relationships",
-        8: "Shared resources, transformation, sexuality, rebirth, others' money",
-        9: "Higher education, philosophy, travel, spirituality, expansion",
-        10: "Career, public reputation, authority, ambition, structure",
-        11: "Friends, groups, hopes, wishes, collective support",
-        12: "Unconscious, hidden strengths/weaknesses, spirituality, isolation"
+        1: "Identity and self-image",
+        2: "Resources and personal values",
+        3: "Learning style and communication",
+        4: "Emotional roots and home life",
+        5: "Creativity, romance and joy",
+        6: "Health habits and daily work",
+        7: "Partnership dynamics",
+        8: "Intimacy and transformation",
+        9: "Beliefs and long journeys",
+        10: "Purpose and public role",
+        11: "Community and aspirations",
+        12: "Inner world and spirituality"
     }

--- a/utils/planet_descriptions.py
+++ b/utils/planet_descriptions.py
@@ -14,31 +14,31 @@ def get_planet_description(planet_name):
         A string describing the planet's practical significance in real-world terms
     """
     descriptions = {
-        "Sun": "The Sun represents your core personality traits, confidence level, and natural talents. Its position can indicate your leadership style, how you express authority in professional settings, and the ways you seek recognition. A strong Sun often correlates with clear career direction and the ability to make independent decisions.",
-        
-        "Moon": "The Moon represents your emotional patterns, comfort needs, and instinctive reactions. Its position can indicate how you handle stress, your relationship with family members, and your emotional intelligence. The Moon's influence often appears in your home environment preferences and how you nurture relationships.",
-        
-        "Mercury": "Mercury represents your communication style, learning methods, and decision-making process. Its position can indicate your educational strengths, how you express ideas at work, and your approach to problem-solving. Mercury often manifests in your technological aptitude, writing abilities, and effectiveness in negotiations.",
-        
-        "Venus": "Venus represents your relationship patterns, aesthetic preferences, and financial habits. Its position can indicate your approach to partnerships, spending habits, and design sensibilities. Venus influences your diplomatic skills, taste in art and music, and how you maintain harmony in various social contexts.",
-        
-        "Mars": "Mars represents your energy levels, competitive nature, and action patterns. Its position can indicate your work ethic, exercise preferences, and conflict resolution style. Mars often influences career choices related to leadership, athletics, or technical skills, and can show how you pursue goals and handle challenging situations.",
-        
-        "Jupiter": "Jupiter represents your growth opportunities, educational interests, and optimistic tendencies. Its position can indicate potential career advancements, learning paths that bring success, and how you handle expansion in business. Jupiter often relates to international connections, publishing opportunities, and areas where you might experience financial abundance.",
-        
-        "Saturn": "Saturn represents your discipline, structural needs, and areas requiring persistent effort. Its position can indicate career responsibilities, time management challenges, and long-term planning abilities. Saturn often manifests in professional achievements gained through consistent work, organizational skills, and how you handle authority figures.",
-        
-        "Rahu": "Rahu (North Node) represents unfamiliar growth areas, progressive thinking, and innovative talents. Its position can indicate career fields where you can break new ground, technology adoption patterns, and unconventional relationship approaches. Rahu often correlates with areas where taking calculated risks leads to significant advancement.",
-        
-        "Ketu": "Ketu (South Node) represents inherent skills, areas of natural detachment, and analytical abilities. Its position can indicate technical expertise you may take for granted, research capacities, and situations where you benefit from minimalist approaches. Ketu often relates to specialized knowledge, scientific thinking, and areas where you function well independently.",
-        
-        "Uranus": "Uranus represents your innovative thinking, adaptability to change, and technological aptitude. Its position can indicate which career fields might experience sudden shifts, where you're likely to implement progressive solutions, and your capacity for original thinking. Uranus often influences your approach to digital technologies and collaborative projects.",
-        
-        "Neptune": "Neptune represents your creative imagination, sensitivity to environments, and pattern recognition abilities. Its position can indicate potential in artistic fields, vulnerability to misinformation, and capacity for empathetic leadership. Neptune often manifests in photography skills, music appreciation, and your approach to healthcare and wellness.",
-        
-        "Pluto": "Pluto represents your capacity for in-depth analysis, resource management, and transformative leadership. Its position can indicate areas where you excel at research, power dynamics in professional settings, and psychological insight. Pluto often correlates with investigative abilities, financial strategy, and organizational restructuring skills.",
-        
-        "Ascendant": "The Ascendant represents your natural physical energy patterns, first impression style, and practical approach to new situations. Its position strongly influences your body type, instinctive health habits, and personal presentation. The Ascendant manifests in how you adapt to different social and professional environments and often correlates with your natural strengths in first impressions."
+        "Sun": "The Sun illustrates the seat of personal vitality and purpose. It reveals how you feel seen and how you compensate when insecurity arises. When integrated, it guides confidence and warmth; when wounded, it may seek approval or dominate. This placement highlights the path to authentic self-expression.",
+
+        "Moon": "The Moon describes your emotional memory and instinctive reactions. It shows how you soothe yourself when anxious or cling to habits from childhood. Here we see where you seek safety, sometimes by retreating or over-nurturing. Awareness fosters emotional regulation and healthier attachment.",
+
+        "Mercury": "Mercury governs perception and communication patterns. It maps how you process information and express thoughts under stress. This planet highlights coping styles like overthinking, humor, or avoidance when feeling unheard. Understanding Mercury refines your voice and mental agility.",
+
+        "Venus": "Venus reveals your capacity for love, pleasure, and self-worth. It shows how you attract connection or build walls to avoid hurt. This placement influences financial choices and aesthetic preferences. Working with Venus softens self-judgment and deepens relational harmony.",
+
+        "Mars": "Mars channels your assertive drive and management of anger. It exposes impulses used to defend, compete, or avoid confrontation. When conscious, Mars offers courage and healthy boundaries instead of reckless force. This placement teaches how to pursue desires without harm.",
+
+        "Jupiter": "Jupiter expands your worldview and sense of possibility. It outlines how optimism or excess shapes your growth. Under stress, you may overreach; when balanced, you inspire others and explore new horizons. Jupiter points to experiences that cultivate meaning and generosity.",
+
+        "Saturn": "Saturn symbolizes structure, responsibility, and fear of inadequacy. It shows where you compensate with hard work or withdrawal due to self-criticism. By facing these tests patiently, you build resilience and realistic confidence. Saturn teaches maturity through sustained effort.",
+
+        "Rahu": "Rahu (North Node) depicts yearning for unfamiliar experiences. It can fuel obsession with novelty or status when insecurity bites. Engaged mindfully, Rahu promotes bold experimentation and progressive thinking. This point suggests stepping into discomfort to accelerate growth.",
+
+        "Ketu": "Ketu (South Node) signals ingrained skills and tendencies toward detachment. You may retreat or undervalue these abilities, seeing them as ordinary. Recognizing Ketu helps you access quiet expertise without isolation and invites balance between independence and reliance.",
+
+        "Uranus": "Uranus reflects your urge for freedom and authentic individuality. Sudden changes or rebellious impulses may surface when you feel restricted. Expressed consciously, Uranus inspires innovation and unconventional insight. It teaches adaptability and the courage to break outdated patterns.",
+
+        "Neptune": "Neptune speaks to imagination, spirituality, and sensitivity to collective moods. It may blur boundaries, leading to escapism or idealization when reality feels harsh. Channeled well, Neptune fosters compassion, artistic vision, and subtle perception. This placement encourages discerning inspiration from illusion.",
+
+        "Pluto": "Pluto reveals core desires for transformation and control. It exposes areas where power struggles or deep fears push you toward regeneration. Confronting Pluto's intensity promotes psychological insight and the ability to release outworn attachments. It guides profound healing through facing shadow material.",
+
+        "Ascendant": "The Ascendant describes your instinctive approach to life and the impression you make on others. It reflects coping mechanisms used to protect identity when under pressure. Embracing its qualities allows authentic presence and adaptability. This point sets the tone for your personal journey."
     }
     
     # Return the description if available, otherwise a generic message

--- a/utils/position_interpretations.py
+++ b/utils/position_interpretations.py
@@ -399,20 +399,20 @@ def get_house_meaning(house_number, sign_name):
     Returns:
         A string describing practical applications of this house-sign combination
     """
-    # House general meanings - practical life areas
+    # House themes highlighting psychological focus
     house_areas = {
-        1: "Personal approach and physical energy",
-        2: "Financial resources and material security",
-        3: "Communication style and immediate environment",
-        4: "Home environment and family foundations",
-        5: "Creative expression and recreational activities",
-        6: "Work routines and health management",
-        7: "Partnerships and significant relationships",
-        8: "Shared resources and transformative processes",
-        9: "Higher education and broader worldview",
-        10: "Career direction and public reputation",
-        11: "Social networks and long-term goals",
-        12: "Subconscious patterns and private challenges"
+        1: "The 1st house reveals how you shape identity and react when feeling exposed. It shows whether courage or caution colors your self-image.",
+        2: "The 2nd house explores resources and self-worth. It reflects how you chase stability or cling to possessions when insecure.",
+        3: "The 3rd house examines learning style and immediate connections. It indicates whether you share ideas freely or retreat into silence under stress.",
+        4: "The 4th house speaks to emotional roots and family conditioning. It reveals how you nurture yourself and seek safety at home.",
+        5: "The 5th house expresses creativity and personal joy. It shows whether you risk sharing talents or guard them against judgment.",
+        6: "The 6th house addresses daily habits and self-care. It highlights coping strategies for stress and the tension between perfectionism and compassion.",
+        7: "The 7th house reveals patterns in partnership and projection. It exposes how you negotiate autonomy and cooperation in close relationships.",
+        8: "The 8th house delves into intimacy, power, and transformation. It uncovers how you handle vulnerability and profound change.",
+        9: "The 9th house looks at beliefs and expansive journeys. It shows how you seek meaning or cling to dogma when growth feels uncertain.",
+        10: "The 10th house reflects ambition and public standing. It indicates how authority figures shape your drive for purposeful success.",
+        11: "The 11th house explores community ties and future ideals. It shows how you connect with groups and rely on networks for support.",
+        12: "The 12th house uncovers subconscious habits and spiritual longings. It highlights where retreat or escapism can become a coping style."
     }
     
     # Get the base house meaning
@@ -435,9 +435,9 @@ def get_house_meaning(house_number, sign_name):
     }
     
     # Get the sign influence
-    influence = sign_influences.get(sign_name, "unknown influence on")
-    
-    # Combine them into a practical interpretation
-    interpretation = f"Shows a {influence} {base_meaning.lower()}."
+    influence = sign_influences.get(sign_name, "distinct approach to")
+
+    # Combine them into a reflective interpretation
+    interpretation = f"{base_meaning} With {sign_name}, you approach this area in a {influence} way."
     
     return interpretation


### PR DESCRIPTION
## Summary
- apply Cinzel and Open Sans fonts, update starry color scheme
- style Ascendant and Planetary sections with light grey background
- recolor zodiac names and add house-name gradient
- move planet descriptions above houses and rename house cusp heading
- rewrite planet and house descriptions with introspective tone

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff5b22de4832ba776077118a0a9c2