### PR TITLE
Add psychological planet sign descriptions

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,6 +28,7 @@ from utils.geocoding import get_coordinates
 from utils.astronomy import calculate_planet_positions, get_zodiac_sign
 from utils.astrology import get_nakshatra, get_house_meanings
 from utils.planet_descriptions import get_planet_description
+from utils.psych_descriptions import get_planet_sign_description
 from utils.position_interpretations import (
     get_planet_in_sign_interpretation,
     get_house_meaning,
@@ -518,6 +519,9 @@ def calculate_skyfield():
             planet["interpretation"] = get_planet_in_sign_interpretation(
                 planet["name"], planet["sign"]
             )
+            planet["psychological_description"] = get_planet_sign_description(
+                planet["name"], planet["sign"]
+            )
 
         # Add interpretation to each house
         for h in houses:
@@ -732,6 +736,9 @@ def calculate():
         for planet in planets:
             planet["nakshatra"] = get_nakshatra_from_longitude(planet["longitude"])
             planet["description"] = get_planet_in_sign_interpretation(
+                planet["name"], planet["sign"]
+            )
+            planet["psychological_description"] = get_planet_sign_description(
                 planet["name"], planet["sign"]
             )
 

--- a/utils/psych_descriptions.py
+++ b/utils/psych_descriptions.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+"""Psychological planet-in-sign descriptions."""
+
+planet_sign_descriptions = {
+    "Sun": {
+        "Aries": "The Sun in Aries asserts identity through action, boldness, and instinctive leadership. There's a psychological drive to prove worth by initiating change, even at the cost of patience. This placement often masks vulnerability with intensity and momentum.",
+        "Taurus": "The Sun in Taurus seeks self-worth through stability, productivity, and control. Security and predictability become core emotional needs. Identity is rooted in values, but change can feel threatening to self-image.",
+        "Gemini": "The Sun in Gemini defines itself through learning, speaking, and connecting ideas. Mental agility and adaptability serve as defenses against emotional discomfort. Self-worth may become tied to intellectual performance or social validation.",
+        "Cancer": "The Sun in Cancer finds identity through emotional bonding and protection of loved ones. There is a deep need to feel needed in order to feel real. Personal strength often hides behind nurturance, loyalty, and sensitivity.",
+        "Leo": "The Sun in Leo expresses identity through creativity, visibility, and the desire to be special. Self-esteem depends on recognition and affirmation. This placement often battles the fear of being ordinary or overlooked.",
+        "Virgo": "The Sun in Virgo defines worth through competence, precision, and service. Self-criticism replaces self-expression when perfection is the goal. Identity is often shaped by the need to fix, improve, or avoid mistakes.",
+        "Libra": "The Sun in Libra seeks identity through balance, beauty, and relational harmony. Approval becomes a mirror for self-worth. This placement may struggle with indecision when the self is defined by others' expectations.",
+        "Scorpio": "The Sun in Scorpio asserts itself through emotional depth, secrecy, and psychological power. Trust and control become key identity themes. Self-expression may be guarded, intense, or tied to transformation through crisis.",
+        "Sagittarius": "The Sun in Sagittarius expresses identity through expansion, freedom, and meaning-making. Truth becomes a guiding principle, often masking an inner restlessness or fear of limitation. Self-worth is tied to vision and possibility.",
+        "Capricorn": "The Sun in Capricorn grounds identity in responsibility, structure, and achievement. There’s a deep drive to prove worth through discipline and success. Underneath is often a fear of inadequacy or being unworthy without performance.",
+        "Aquarius": "The Sun in Aquarius builds identity through uniqueness, ideals, and rebellion against conformity. Belonging often feels conditional, so individuality becomes armor. There may be emotional detachment when vulnerability feels unsafe.",
+        "Pisces": "The Sun in Pisces dissolves boundaries of identity to merge with inspiration, suffering, or spirit. There is a longing to feel divine purpose, but also a tendency to lose oneself in others or fantasy. Self-worth may fluctuate with emotional tides."
+    },
+    "Moon": {
+        "Aries": "The Moon in Aries reacts quickly and emotionally, seeking safety through control and movement. Emotional needs are expressed through anger, urgency, or taking charge. Vulnerability often hides behind defensiveness or impulsive responses.",
+        "Taurus": "The Moon in Taurus seeks emotional stability through routine, comfort, and material security. Feelings are slow to shift but deeply held. There's resistance to change, but a strong inner capacity to self-soothe and endure.",
+        "Gemini": "The Moon in Gemini regulates emotion through analysis, distraction, and verbal expression. Feelings may be intellectualized or split into ideas. Emotional distance can be a defense against chaos or inconsistency.",
+        "Cancer": "The Moon in Cancer is highly attuned to emotional waves and often absorbs others' feelings. Security is found in belonging and caretaking. This placement needs safe space to retreat, but can become overly attached or self-protective.",
+        "Leo": "The Moon in Leo seeks emotional validation through attention and admiration. There's a strong need to be special in the eyes of loved ones. Wounds may form around being overlooked or unrecognized emotionally.",
+        "Virgo": "The Moon in Virgo manages feelings by controlling the environment or self. Emotions are filtered through logic, critique, or caretaking. Inner anxiety often arises from unmet expectations or fear of imperfection.",
+        "Libra": "The Moon in Libra regulates through connection and harmony. Emotional needs are often suppressed to maintain peace. This placement may struggle with codependence or emotional indecision.",
+        "Scorpio": "The Moon in Scorpio feels deeply but hides vulnerability behind intensity and control. Trust must be earned, and emotional expression may be guarded. It seeks emotional fusion but fears betrayal or exposure.",
+        "Sagittarius": "The Moon in Sagittarius finds emotional release through truth, exploration, and distance. Feelings are tied to meaning or belief. This placement defends against emotional restriction by staying in motion or focused on ideals.",
+        "Capricorn": "The Moon in Capricorn filters emotion through responsibility, self-control, and practicality. Emotional needs are often postponed or internalized. There’s a fear of dependency and a drive to prove emotional self-sufficiency.",
+        "Aquarius": "The Moon in Aquarius detaches from emotion to protect individuality or mental clarity. Feelings are observed rather than felt. There may be difficulty accessing or trusting emotional depth.",
+        "Pisces": "The Moon in Pisces absorbs emotional environments and seeks unity with something larger. It may blur boundaries between self and others. Sensitivity can lead to compassion—or emotional confusion and escapism."
+    },
+    "Mercury": {
+        "Aries": "Mercury in Aries thinks and speaks impulsively, often before fully processing. Ideas are driven by instinct and urgency. Communication may be direct, forceful, or defensive.",
+        "Taurus": "Mercury in Taurus processes slowly but with depth and clarity. Ideas are grounded and practical. There’s resistance to change but strong mental endurance.",
+        "Gemini": "Mercury in Gemini thrives on information, stimulation, and conversation. It jumps between ideas quickly. May struggle with focus or emotional detachment in communication.",
+        "Cancer": "Mercury in Cancer thinks with emotion and memory. Words are colored by past experiences and protective instincts. Communication is nurturing but can become defensive or moody.",
+        "Leo": "Mercury in Leo communicates with flair, passion, and pride. Ideas are tied to identity. Criticism may be taken personally, and expression seeks validation.",
+        "Virgo": "Mercury in Virgo analyzes everything and seeks clarity. It communicates with precision and concern for accuracy. Anxiety may emerge when things feel disorganized.",
+        "Libra": "Mercury in Libra considers both sides before speaking. It seeks fairness and peace in communication. Indecision or people-pleasing may distort clarity.",
+        "Scorpio": "Mercury in Scorpio communicates with depth, secrecy, and strategic awareness. Words are rarely casual. There’s a need to uncover hidden truths—and protect one’s own.",
+        "Sagittarius": "Mercury in Sagittarius expresses ideas through beliefs, optimism, or blunt honesty. It can overgeneralize or avoid nuance. Values may override facts.",
+        "Capricorn": "Mercury in Capricorn structures thoughts for utility and control. Communication is clear but cautious. There may be fear of speaking wrongly or emotionally.",
+        "Aquarius": "Mercury in Aquarius thinks abstractly, idealistically, or eccentrically. Detachment allows for innovation, but can suppress emotion. Ideas often challenge norms.",
+        "Pisces": "Mercury in Pisces blends intuition, imagination, and emotion. It communicates in symbols and feelings more than logic. Boundaries between thought and fantasy may blur."
+    },
+    "Venus": {
+        "Aries": "Venus in Aries seeks love through pursuit, intensity, and directness. Affection is impulsive but can burn out quickly. There's a fear of vulnerability behind the chase.",
+        "Taurus": "Venus in Taurus desires sensual, steady, and loyal connections. Love is expressed through physical presence and security. Resistance to emotional risk can block deeper intimacy.",
+        "Gemini": "Venus in Gemini values playful, verbal, and stimulating connection. Affection often flows through curiosity and conversation. Emotional depth may be replaced by mental engagement.",
+        "Cancer": "Venus in Cancer bonds through caretaking, emotional attunement, and safety. Love feels sacred but fragile. There's a risk of overattachment or emotional enmeshment.",
+        "Leo": "Venus in Leo needs to feel adored, seen, and valued. Love is dramatic, expressive, and generous. Wounds may form when attention is withdrawn or love feels unreciprocated.",
+        "Virgo": "Venus in Virgo expresses love through helpfulness, devotion, and refinement. Love must be earned or deserved. The inner critic can sabotage pleasure or softness.",
+        "Libra": "Venus in Libra romanticizes harmony, beauty, and connection. Love is often idealized. The fear of conflict may lead to self-betrayal or indecisiveness in relationships.",
+        "Scorpio": "Venus in Scorpio desires soul-deep union, intensity, and emotional truth. Love feels like risk and rebirth. Jealousy or control can arise from unresolved trust wounds.",
+        "Sagittarius": "Venus in Sagittarius connects through freedom, shared beliefs, and adventure. Love is expansive but may avoid emotional responsibility. Closeness can feel like confinement.",
+        "Capricorn": "Venus in Capricorn seeks loyalty, structure, and long-term value in love. Affection is earned through responsibility. Emotional vulnerability may be replaced with control.",
+        "Aquarius": "Venus in Aquarius values uniqueness, freedom, and mental connection in relationships. Emotional distance may mask the fear of dependency. Love must respect autonomy.",
+        "Pisces": "Venus in Pisces loves unconditionally, spiritually, and often self-sacrificially. Boundaries may blur, leading to fantasy or martyrdom. True love feels transcendent but risky."
+    },
+    "Mars": {
+        "Aries": "Mars in Aries acts instinctively and directly. It channels anger and desire into motion. Impatience may hide deeper fears of being powerless.",
+        "Taurus": "Mars in Taurus moves slowly but with determination. Effort is focused on tangible results. Resistance to change can lead to stubborn repression of anger.",
+        "Gemini": "Mars in Gemini fights with words, wit, or shifting focus. Energy is scattered across ideas. Anger is intellectualized or deflected through logic.",
+        "Cancer": "Mars in Cancer protects emotionally, not aggressively. Action is indirect, often defensive. Anger is repressed until it explodes or turns inward.",
+        "Leo": "Mars in Leo acts with pride, passion, and performative energy. Motivation is driven by being seen. Rejection can trigger ego-based conflict.",
+        "Virgo": "Mars in Virgo channels energy into fixing, improving, or refining. Action becomes obsessive. Anxiety arises from never doing enough.",
+        "Libra": "Mars in Libra hesitates between action and peace. Conflict avoidance leads to inner frustration. Motivation may depend on approval.",
+        "Scorpio": "Mars in Scorpio moves with strategy, intensity, and emotional force. Power is guarded. Rage simmers below the surface until controlled release.",
+        "Sagittarius": "Mars in Sagittarius pursues freedom, truth, and higher goals. Action is bold but inconsistent. Rage can emerge when beliefs are threatened.",
+        "Capricorn": "Mars in Capricorn acts with discipline and ambition. Drive is focused and long-term. Anger is buried until it becomes structured control.",
+        "Aquarius": "Mars in Aquarius breaks patterns through rebellion or invention. Action is erratic but purposeful. Emotional disconnection may lead to impulsive eruptions.",
+        "Pisces": "Mars in Pisces acts through dreams, emotion, or avoidance. Drive may be unfocused or directed toward idealistic escape. Anger becomes sadness or surrender."
+    },
+    "Jupiter": {
+        "Aries": "Jupiter in Aries expands confidence through self-reliance and boldness. Growth comes from action. Impulsivity may replace wisdom.",
+        "Taurus": "Jupiter in Taurus finds meaning through stability, pleasure, and consistency. Growth is slow but enduring. Overattachment to comfort may block change.",
+        "Gemini": "Jupiter in Gemini seeks truth through exploration of ideas. Mental expansion is endless. Scattered focus may dilute depth.",
+        "Cancer": "Jupiter in Cancer grows through empathy, family, and emotional intelligence. Wisdom emerges from caring. Overprotection can stifle independence.",
+        "Leo": "Jupiter in Leo finds faith in creativity and visibility. Self-expression becomes a path to growth. Ego inflation may mask deeper insecurity.",
+        "Virgo": "Jupiter in Virgo expands through precision, service, and refinement. Growth comes from solving problems. Over-analysis may limit joy.",
+        "Libra": "Jupiter in Libra grows through partnership, fairness, and art. Wisdom is relational. Avoiding conflict can distort true belief.",
+        "Scorpio": "Jupiter in Scorpio grows through emotional truth and shadow work. Faith is tested by transformation. Power can be hoarded or healed.",
+        "Sagittarius": "Jupiter in Sagittarius thrives in freedom, belief, and adventure. Growth feels natural but may ignore limits. Righteousness can become a defense.",
+        "Capricorn": "Jupiter in Capricorn expands through structure, responsibility, and legacy. Growth is earned. Fear of failure may limit risk-taking.",
+        "Aquarius": "Jupiter in Aquarius finds truth in innovation and collective ideals. Growth is unconventional. Emotional detachment can bypass wisdom.",
+        "Pisces": "Jupiter in Pisces grows through compassion, mysticism, and surrender. Meaning is intuitive. Escapism can cloud discernment."
+    },
+    "Saturn": {
+        "Aries": "Saturn in Aries fears asserting self. There is tension around action and autonomy. Growth requires trusting one’s instincts.",
+        "Taurus": "Saturn in Taurus clings to control and fears loss. Security is overvalued. Lessons involve flexibility and releasing attachment.",
+        "Gemini": "Saturn in Gemini doubts mental capacity or communication. Fear of being misunderstood can cause silence. Growth lies in authentic expression.",
+        "Cancer": "Saturn in Cancer resists vulnerability. Emotional needs feel dangerous. Healing involves learning safe self-nurturing.",
+        "Leo": "Saturn in Leo fears being seen or unworthy of love. Identity is constructed through performance. Growth lies in self-acceptance.",
+        "Virgo": "Saturn in Virgo fears imperfection and failure. The inner critic dominates. Healing comes through compassion and humility.",
+        "Libra": "Saturn in Libra fears rejection and imbalance. Relationships feel like tests. Growth comes through honest boundaries.",
+        "Scorpio": "Saturn in Scorpio guards emotional truth. Control replaces trust. Transformation requires surrender of fear-based defenses.",
+        "Sagittarius": "Saturn in Sagittarius fears being wrong or trapped. Beliefs become rigid. Growth involves humility and embracing uncertainty.",
+        "Capricorn": "Saturn in Capricorn overidentifies with status or control. Success replaces self-worth. Growth involves vulnerability and authenticity.",
+        "Aquarius": "Saturn in Aquarius fears exclusion and deviation. Identity may be over-intellectualized. Growth lies in grounded connection to humanity.",
+        "Pisces": "Saturn in Pisces fears chaos, surrender, and emotional overwhelm. It creates rigid defenses against softness. Healing comes through trust in the unseen."
+    },
+    "Rahu": {
+        "Aries": "Rahu in Aries craves independence and self-assertion. It hungers for boldness but may rush into conflict. Growth lies in learning healthy courage.",
+        "Taurus": "Rahu in Taurus seeks material security and comfort. It can overconsume or hoard. Growth involves simplicity and emotional self-worth.",
+        "Gemini": "Rahu in Gemini seeks knowledge, language, and adaptability. It may become addicted to stimulation. Growth requires clarity and integration.",
+        "Cancer": "Rahu in Cancer craves nurturing and emotional safety. It may cling to dependency. Growth involves self-parenting and inner stability.",
+        "Leo": "Rahu in Leo wants recognition, creativity, and leadership. It may overperform or dramatize. True growth lies in inner confidence.",
+        "Virgo": "Rahu in Virgo seeks order, healing, and mastery. It may become obsessive. Growth involves acceptance of imperfection.",
+        "Libra": "Rahu in Libra seeks approval, beauty, and relational harmony. It may self-abandon. Growth involves honest connection and balance.",
+        "Scorpio": "Rahu in Scorpio is drawn to intensity, power, and transformation. It may become manipulative. Growth involves surrender and trust.",
+        "Sagittarius": "Rahu in Sagittarius craves belief, expansion, and truth. It may become dogmatic. Growth lies in real experience over theory.",
+        "Capricorn": "Rahu in Capricorn desires control, status, and discipline. It may burn out from ambition. Growth involves presence and emotional maturity.",
+        "Aquarius": "Rahu in Aquarius seeks uniqueness and future vision. It may rebel without grounding. Growth involves humility and group service.",
+        "Pisces": "Rahu in Pisces seeks spiritual ecstasy and escape. It may become lost in illusion. Growth involves discernment and compassionate embodiment."
+    },
+    "Ketu": {
+        "Aries": "Ketu in Aries withdraws from self-assertion. Confidence may feel foreign. Growth involves reclaiming healthy willpower.",
+        "Taurus": "Ketu in Taurus detaches from comfort or physicality. There may be a disconnection from self-worth. Healing involves grounding and embodiment.",
+        "Gemini": "Ketu in Gemini avoids surface communication or multitasking. Words may feel empty. Growth lies in committed learning and clarity.",
+        "Cancer": "Ketu in Cancer withdraws from emotional dependence or family roles. It fears vulnerability. Healing involves safe emotional connection.",
+        "Leo": "Ketu in Leo retreats from attention or pride. There may be fear of being seen. Growth involves authentic self-expression.",
+        "Virgo": "Ketu in Virgo detaches from control and detail. It may become apathetic. Growth involves practical engagement without perfectionism.",
+        "Libra": "Ketu in Libra distances from relationships or diplomacy. It fears imbalance. Healing lies in conscious relating.",
+        "Scorpio": "Ketu in Scorpio lets go of emotional intensity and control. It may avoid transformation. Growth involves conscious emotional engagement.",
+        "Sagittarius": "Ketu in Sagittarius retreats from rigid belief or spiritual inflation. Growth involves practical wisdom and humility.",
+        "Capricorn": "Ketu in Capricorn lets go of duty, structure, or over-responsibility. It may fear failure. Healing involves emotional softness and rest.",
+        "Aquarius": "Ketu in Aquarius detaches from ideology or social roles. It may feel alienated. Growth lies in personal truth and belonging.",
+        "Pisces": "Ketu in Pisces releases escapism, fantasy, and over-idealization. It may become numb. Healing involves grounded spirituality and service."
+    }
+}
+
+
+def get_planet_sign_description(planet, sign):
+    """Return psychological description for a planet in a sign."""
+    return planet_sign_descriptions.get(planet, {}).get(sign, f"Description for {planet} in {sign} not available.")


### PR DESCRIPTION
## Summary
- add `utils/psych_descriptions.py` containing short psychological planet-in-sign interpretations
- include new function `get_planet_sign_description`
- expose descriptions in API responses via `psychological_description` field

## Testing
- `python -m py_compile app.py utils/psych_descriptions.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684003a3c5d4832b9f83fffdb5e20a8e