### PR TITLE
Add sunny orange styling to house numbers

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -282,6 +282,11 @@ header .lead {
     font-family: 'Cinzel', serif;
 }
 
+/* Style for the "House 1", "House 2" labels */
+.house-number {
+    color: var(--bs-primary);
+}
+
 .house-card:nth-child(1) .card-header { color: hsl(240,60%,70%); }
 .house-card:nth-child(2) .card-header { color: hsl(220,60%,70%); }
 .house-card:nth-child(3) .card-header { color: hsl(200,60%,70%); }

--- a/templates/result.html
+++ b/templates/result.html
@@ -171,7 +171,7 @@
                     <div class="col">
                         <div class="card house-card h-100">
                             <div class="card-header bg-dark">
-                                House {{ house.house }}: <span class="sign-{{ house.sign.lower() }}">{{ house.sign }}</span>
+                                <span class="house-number">House {{ house.house }}</span>: <span class="sign-{{ house.sign.lower() }}">{{ house.sign }}</span>
                             </div>
                             <div class="card-body">
                                 <p class="card-text">

--- a/templates/skyfield_form.html
+++ b/templates/skyfield_form.html
@@ -205,7 +205,7 @@
                         houseBody.className = 'card-body';
                         
                         const houseTitle = document.createElement('h5');
-                        houseTitle.className = 'card-title';
+                        houseTitle.className = 'card-title house-number';
                         houseTitle.textContent = `House ${house.house}`;
                         
                         const houseSign = document.createElement('p');


### PR DESCRIPTION
## Summary
- make house number labels sunny orange
- update result and form templates with new `house-number` class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400dbe0eb8832bb9b35d504038d2ec