### PR TITLE
Align backgrounds for result sections

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -68,15 +68,6 @@ header .lead {
     font-family: 'Cinzel', serif;
 }
 
-.ascendant-header, .planetary-header {
-    background-color: #f5f5f5 !important;
-    color: var(--bs-primary) !important;
-}
-
-.ascendant-section, .planetary-section {
-    background-color: #f5f5f5;
-    color: #333;
-}
 
 .card-body {
     padding: 1.5rem;

--- a/templates/result.html
+++ b/templates/result.html
@@ -49,8 +49,8 @@
         
         <!-- Ascendant Section -->
         {% if ascendant %}
-        <div class="card mb-4 ascendant-section">
-            <div class="card-header ascendant-header">
+        <div class="card mb-4">
+            <div class="card-header bg-secondary text-white">
                 <div class="d-flex justify-content-between align-items-center">
                     <h3 class="mb-0">Ascendant (Lagna)</h3>
                     <span class="badge bg-info" data-bs-toggle="tooltip" title="Calculated using Skyfield precision astronomical algorithms">
@@ -74,8 +74,8 @@
         {% endif %}
 
         <!-- Planets Section -->
-        <div class="card mb-4 planetary-section">
-            <div class="card-header planetary-header">
+        <div class="card mb-4">
+            <div class="card-header bg-secondary text-white">
                 <h3 class="mb-0">Planetary Positions</h3>
             </div>
             <div class="card-body">


### PR DESCRIPTION
## Summary
- unify Ascendant and Planetary Positions sections with Planet Descriptions
- remove unused style rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400d1a49b4832ba024fe0de495d6b8