### PR TITLE
Add sign-specific house cusp descriptions

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,7 +28,10 @@ from utils.geocoding import get_coordinates
 from utils.astronomy import calculate_planet_positions, get_zodiac_sign
 from utils.astrology import get_nakshatra, get_house_meanings
 from utils.planet_descriptions import get_planet_description
-from utils.psych_descriptions import get_planet_sign_description
+from utils.psych_descriptions import (
+    get_planet_sign_description,
+    get_house_sign_description,
+)
 from utils.position_interpretations import (
     get_planet_in_sign_interpretation,
     get_house_meaning,
@@ -526,6 +529,9 @@ def calculate_skyfield():
         # Add interpretation to each house
         for h in houses:
             h["interpretation"] = get_house_meaning(h["house"], h["sign"])
+            h["psychological_description"] = get_house_sign_description(
+                h["house"], h["sign"]
+            )
 
         # Create response data
         response_data = {
@@ -770,7 +776,10 @@ def calculate():
         for i in range(12):
             sign = ZODIAC_SIGNS[(asc_index + i) % 12]
             house = {"house": i+1, "sign": sign, "degree": 0.0, "formatted": f"{sign} 0°"}
-            house["meaning"] = get_house_meaning(i+1, sign)
+            house["meaning"] = get_house_meaning(i + 1, sign)
+            house["psychological_description"] = get_house_sign_description(
+                i + 1, sign
+            )
             houses.append(house)
         house_data = {"ascendant": ascendant_position, "houses": houses}
 

--- a/utils/psych_descriptions.py
+++ b/utils/psych_descriptions.py
@@ -130,7 +130,195 @@ planet_sign_descriptions = {
     }
 }
 
+# Additional descriptions for house cusps in each sign -----------------------
+house_sign_descriptions = {
+    "1st House": {
+        "Aries": "The Aries Ascendant radiates urgency, assertiveness, and instinctive independence. The self is shaped by action and confrontation. Life pushes this person to face their impulsivity and learn mindful courage.",
+        "Taurus": "With Taurus rising, the identity forms through stability, beauty, and physical presence. There is resistance to change and a strong attachment to routine. Life challenges this person to soften control and discover inner security.",
+        "Gemini": "Gemini rising creates a self-image through words, wit, and versatility. The person is seen as curious and quick, yet may hide anxiety behind mental speed. Growth requires slowing down and integrating emotion with thought.",
+        "Cancer": "Cancer on the Ascendant filters life through emotional sensitivity and protective instincts. The self is shaped by past attachments and a deep need for safety. This person must learn to self-soothe without withdrawing.",
+        "Leo": "Leo rising presents a bold, expressive, and radiant self. Identity is shaped by being seen and validated. Life pushes this person to find confidence that isn’t dependent on attention.",
+        "Virgo": "With Virgo rising, identity is filtered through self-improvement, responsibility, and humility. There's often a critical inner lens and a need to be useful. Healing begins when worth isn’t tied to perfection.",
+        "Libra": "Libra rising seeks to be seen as likable, graceful, and balanced. The self forms in relation to others. The journey involves setting boundaries and allowing authenticity to take priority over harmony.",
+        "Scorpio": "Scorpio Ascendant wears a guarded, intense, and emotionally perceptive identity. There’s a deep need to protect the self from betrayal or loss of power. Growth lies in allowing trust without losing control.",
+        "Sagittarius": "With Sagittarius rising, the identity expands through adventure, belief, and inspiration. This person is seen as optimistic or restless. Their soul seeks grounded purpose, not just movement.",
+        "Capricorn": "Capricorn on the Ascendant expresses a controlled, mature, and competent self. The inner world may be full of self-judgment or fear of inadequacy. Growth means allowing softness and redefining success.",
+        "Aquarius": "Aquarius rising projects uniqueness, detachment, and intellect. This person often feels separate, even among others. Healing comes from embracing vulnerability beneath the difference.",
+        "Pisces": "Pisces Ascendant filters life through emotion, empathy, and dreamlike perception. The self may dissolve in others or fantasy. The journey involves anchoring identity without losing the soul’s fluid nature."
+    },
+    "2nd House": {
+        "Aries": "In Aries, the 2nd House connects self-worth to action, initiative, and conquest. There is a drive to earn, claim, and defend resources. Emotional safety is tied to autonomy.",
+        "Taurus": "With Taurus on the 2nd, self-worth grows through consistency, beauty, and tangible security. Material stability is deeply tied to inner peace. The risk is overidentifying with possessions.",
+        "Gemini": "Gemini in the 2nd House links value to intellect, communication, and flexibility. Worth is mentally constructed and often fluctuating. Emotional safety may depend on verbal validation.",
+        "Cancer": "Cancer in the 2nd House ties value to emotional bonds and security. Self-worth is rooted in nurture or being needed. Financial or emotional instability threatens inner safety.",
+        "Leo": "With Leo in the 2nd, worth is tied to being seen, admired, or creative. Earning becomes performance. Inner growth means detaching value from validation.",
+        "Virgo": "Virgo here creates self-worth through productivity, perfection, and service. There’s an inner critic tied to money or usefulness. The lesson is to embrace value beyond function.",
+        "Libra": "Libra on the 2nd ties self-worth to harmony, appearance, or relationships. Pleasing others becomes currency. Healing comes through claiming intrinsic worth.",
+        "Scorpio": "Scorpio in the 2nd intensifies the connection between control, survival, and value. Trust issues may extend to money or intimacy. Growth means surrendering fear-based scarcity.",
+        "Sagittarius": "Sagittarius on the 2nd seeks value through meaning, beliefs, and experience. Materialism is replaced with philosophy or freedom. Worth must be grounded, not only imagined.",
+        "Capricorn": "Capricorn here defines worth through achievement, structure, and long-term success. Fear of failure can become self-rejection. Growth means softening the worth–work equation.",
+        "Aquarius": "Aquarius in the 2nd values uniqueness, ideals, and mental detachment. Traditional security may feel foreign. The journey involves finding stability in inner freedom.",
+        "Pisces": "Pisces in the 2nd blends value with spiritual, emotional, or artistic energy. Boundaries around possessions or worth may be blurred. Growth comes from anchoring dreams in reality."
+    },
+    "3rd House": {
+        "Aries": "In Aries, the 3rd House energizes speech, curiosity, and learning through action. Thoughts come quickly, often impulsively. Growth involves listening and patience.",
+        "Taurus": "Taurus in the 3rd House brings a steady, grounded mind. Communication is careful, reliable, and resistant to change. The soul grows through flexible thinking.",
+        "Gemini": "Gemini here makes communication central. Curiosity drives learning, but depth may be sacrificed for variety. Integration brings clarity.",
+        "Cancer": "Cancer on the 3rd filters thought through emotion and memory. Words may serve as shields. Emotional literacy deepens growth.",
+        "Leo": "Leo in the 3rd House adds drama and pride to communication. Ideas are tied to identity. Growth comes from humility and openness.",
+        "Virgo": "Virgo here sharpens analysis, precision, and internal dialogue. Thoughts often become self-critical. Growth involves softening the inner voice.",
+        "Libra": "Libra in the 3rd seeks harmony in communication. Words are chosen for peace, not always truth. Growth lies in honest dialogue.",
+        "Scorpio": "Scorpio here gives the mind intensity and secrecy. Thoughts go deep but are hidden. Growth requires trust in sharing truth.",
+        "Sagittarius": "Sagittarius on the 3rd sees the world through beliefs and meaning. Ideas are visionary but may overlook detail. Growth lies in grounded inquiry.",
+        "Capricorn": "Capricorn here brings caution, structure, and focus to the mind. Ideas are tools. Growth means releasing fear of being wrong.",
+        "Aquarius": "Aquarius in the 3rd House inspires innovation and mental independence. Thoughts may be ungrounded. Growth lies in connecting head and heart.",
+        "Pisces": "Pisces here thinks symbolically, emotionally, and with intuition. Logic may blur. Growth requires grounding mental energy."
+    },
+    "4th House": {
+        "Aries": "Aries in the 4th House energizes home life but may create early emotional battles. Inner safety requires learning emotional regulation.",
+        "Taurus": "Taurus in the 4th seeks peace, routine, and emotional grounding. Resistance to change can block inner evolution.",
+        "Gemini": "Gemini here brings a restless emotional base. Early life may have lacked consistency. Growth comes through emotional curiosity.",
+        "Cancer": "Cancer in the 4th deeply roots the soul in family, memory, and inner security. Emotional safety is essential for all growth.",
+        "Leo": "Leo in the 4th seeks admiration and pride within the family. Home may be a stage. Growth lies in emotional authenticity.",
+        "Virgo": "Virgo here creates order at home, but often criticizes the self internally. Growth comes from emotional self-compassion.",
+        "Libra": "Libra in the 4th wants harmony and fairness in the emotional world. Conflict is feared. Growth lies in authentic feelings.",
+        "Scorpio": "Scorpio in the 4th holds emotional secrets and deep intensity. Trust was often broken early. Healing lies in emotional release.",
+        "Sagittarius": "Sagittarius here makes home a place of learning or belief. Emotional restlessness can prevent deep roots. Growth is found in presence.",
+        "Capricorn": "Capricorn in the 4th brings responsibility to family and emotion. Early life may have felt burdensome. Healing comes from rest and softness.",
+        "Aquarius": "Aquarius in the 4th detaches from emotion to survive. Family may have felt alien. Healing means connecting to emotional truth.",
+        "Pisces": "Pisces here merges fantasy and emotion. Boundaries were likely unclear in childhood. Healing comes through spiritual grounding."
+    },
+    "5th House": {
+        "Aries": "Aries in the 5th House creates bold expression and competitive creativity. The challenge is expressing joy without domination.",
+        "Taurus": "Taurus here expresses through sensuality, nature, and beauty. Joy is slow and deep. Risk lies in stagnation.",
+        "Gemini": "Gemini in the 5th creates through play, words, and ideas. Expression is lively but scattered. Growth involves emotional anchoring.",
+        "Cancer": "Cancer here expresses from emotional depth and nostalgia. Creativity is personal. Growth involves allowing visibility.",
+        "Leo": "Leo in the 5th thrives on expression, pride, and love. The self is validated through creation. Growth involves detaching from applause.",
+        "Virgo": "Virgo in the 5th refines creativity with precision and service. Fear of imperfection may block joy. Growth lies in playfulness.",
+        "Libra": "Libra here creates beauty and connection through partnership. Joy comes from harmony. Growth involves expressing authentic desire.",
+        "Scorpio": "Scorpio in the 5th expresses through intensity and transformation. Love may be all-or-nothing. Healing involves trust in joy.",
+        "Sagittarius": "Sagittarius here creates through expansion, truth, and philosophy. Joy is tied to exploration. Growth lies in presence.",
+        "Capricorn": "Capricorn in the 5th expresses cautiously. Joy is earned. Growth involves releasing fear of failure in creation.",
+        "Aquarius": "Aquarius here brings innovation and rebellion to creative life. Expression may lack emotion. Growth involves reconnecting to the heart.",
+        "Pisces": "Pisces in the 5th creates from dreams, emotion, and spirit. Expression may feel chaotic. Grounded imagination brings healing."
+    },
+    "6th House": {
+        "Aries": "Aries in the 6th brings urgency and assertion to work and health. Routine becomes a battleground. Growth involves discipline without burnout.",
+        "Taurus": "Taurus here needs stability and comfort in daily life. Resistance to change may hinder healing. Growth lies in gentle evolution.",
+        "Gemini": "Gemini in the 6th thrives in mental variety and quick tasks. The mind overstimulates the body. Growth involves grounding and focus.",
+        "Cancer": "Cancer here nurtures through service but absorbs emotional weight. Self-neglect is common. Growth requires emotional boundaries.",
+        "Leo": "Leo in the 6th expresses pride through service and creativity. Validation may be tied to work. Growth involves inner fulfillment.",
+        "Virgo": "Virgo here is at home—careful, efficient, yet overly critical. Healing involves acceptance of imperfection.",
+        "Libra": "Libra in the 6th seeks harmony in routine and work. Conflict is avoided. Growth lies in fair self-care and truth.",
+        "Scorpio": "Scorpio in the 6th brings emotional intensity to health and service. Work becomes control. Growth means softening perfectionism.",
+        "Sagittarius": "Sagittarius here resists constraint and needs meaningful work. Daily life becomes philosophy. Growth lies in structured freedom.",
+        "Capricorn": "Capricorn in the 6th thrives on duty and results. Work ethic is high, but so is self-pressure. Growth means valuing rest.",
+        "Aquarius": "Aquarius here innovates routine and defies norms. Chaos may override care. Growth involves consistency and balance.",
+        "Pisces": "Pisces in the 6th sacrifices self in service. Boundaries blur. Healing requires spiritual and physical integration."
+    },
+    "7th House": {
+        "Aries": "Aries in the 7th seeks bold, assertive partners. Conflict is common. Growth lies in collaboration without losing self.",
+        "Taurus": "Taurus here needs stable, loyal relationships. Resistance to change may create stagnation. Growth comes from emotional risk.",
+        "Gemini": "Gemini in the 7th seeks mental stimulation in love. Commitment feels constraining. Growth involves depth over distraction.",
+        "Cancer": "Cancer here bonds deeply but fears abandonment. Emotional fusion is common. Growth lies in emotional differentiation.",
+        "Leo": "Leo in the 7th needs admiration and loyalty. Partnerships may mirror ego needs. Growth means mutual visibility.",
+        "Virgo": "Virgo here chooses selectively and serves through love. Over-analysis can block intimacy. Growth involves letting love be messy.",
+        "Libra": "Libra in the 7th seeks ideal balance and beauty in relationships. Harmony may be pursued at the cost of truth. Growth is found in real connection.",
+        "Scorpio": "Scorpio here seeks depth, intensity, and loyalty. Control issues may arise. Healing comes through emotional vulnerability.",
+        "Sagittarius": "Sagittarius in the 7th seeks partners who inspire and expand. Freedom is essential. Growth means emotional presence.",
+        "Capricorn": "Capricorn here commits seriously and cautiously. Fear of failure may hinder intimacy. Growth involves emotional trust.",
+        "Aquarius": "Aquarius in the 7th seeks unconventional or intellectual unions. Detachment may block connection. Growth lies in embodied presence.",
+        "Pisces": "Pisces here merges in love and may idealize partners. Boundaries dissolve. Growth involves loving without losing self."
+    },
+    "8th House": {
+        "Aries": "Aries in the 8th faces transformation through conflict and survival. Power is pursued directly. Growth involves surrender.",
+        "Taurus": "Taurus here resists emotional death and clings to safety. Transformation is slow. Growth lies in trusting change.",
+        "Gemini": "Gemini in the 8th intellectualizes trauma. Emotions are analyzed, not felt. Growth involves embodied truth.",
+        "Cancer": "Cancer here bonds deeply and guards pain. Vulnerability is sacred. Healing requires safe surrender.",
+        "Leo": "Leo in the 8th seeks power through love and self-expression. Ego may resist transformation. Growth is found in humility.",
+        "Virgo": "Virgo here dissects pain to control it. Perfection masks wounds. Healing requires acceptance of chaos.",
+        "Libra": "Libra in the 8th seeks peace through emotional depth but fears loss. Healing means embracing emotional truth.",
+        "Scorpio": "Scorpio in the 8th is at home with intensity. Control protects wounds. Growth involves trust and softness.",
+        "Sagittarius": "Sagittarius here transforms through belief, travel, or crisis. Avoidance is spiritualized. Growth lies in grounded healing.",
+        "Capricorn": "Capricorn in the 8th builds emotional walls. Power is earned. Healing involves inner permission to feel.",
+        "Aquarius": "Aquarius here detaches from emotional intensity. Transformation may feel alien. Growth means reconnecting to body and soul.",
+        "Pisces": "Pisces in the 8th merges spiritually but loses boundaries. Emotional overwhelm is common. Healing involves anchored sensitivity."
+    },
+    "9th House": {
+        "Aries": "Aries in the 9th pursues belief through action and challenge. Conviction is impulsive. Growth involves open-minded exploration.",
+        "Taurus": "Taurus here finds faith in nature, art, and consistency. Beliefs are slow to change. Growth lies in spiritual flexibility.",
+        "Gemini": "Gemini in the 9th learns through variety and debate. Philosophy may be scattered. Growth means deepening one path.",
+        "Cancer": "Cancer here believes from the heart. Faith is emotional. Growth lies in integrating logic with intuition.",
+        "Leo": "Leo in the 9th shines through belief and teaching. Faith is self-affirming. Growth involves humility and listening.",
+        "Virgo": "Virgo here analyzes philosophy. Beliefs must be practical. Growth means trusting the unprovable.",
+        "Libra": "Libra in the 9th seeks beauty in belief. Ideals may be borrowed. Growth lies in owning one’s truth.",
+        "Scorpio": "Scorpio in the 9th transforms through dark truths and sacred texts. Faith must be felt. Growth involves softening dogma.",
+        "Sagittarius": "Sagittarius in the 9th is at home. Belief is expansive and bold. Growth involves patience with others’ truths.",
+        "Capricorn": "Capricorn in the 9th finds meaning through structure and legacy. Beliefs are earned. Growth means letting go of rigid doctrine.",
+        "Aquarius": "Aquarius here innovates beliefs. Faith is future-oriented. Growth lies in grounded application.",
+        "Pisces": "Pisces in the 9th dissolves boundaries of truth. Faith is intuitive and imaginative. Growth involves grounded discernment."
+    },
+    "10th House": {
+        "Aries": "Aries in the 10th leads with action and force. Career becomes a battlefield. Growth involves conscious ambition.",
+        "Taurus": "Taurus here builds slowly and persistently. Career is tied to comfort. Growth lies in stepping outside the comfort zone.",
+        "Gemini": "Gemini in the 10th thrives through ideas, speech, and variety. Restlessness may block mastery. Growth involves consistency.",
+        "Cancer": "Cancer here nurtures through public service. Career mirrors emotional needs. Growth comes from self-containment.",
+        "Leo": "Leo in the 10th seeks recognition and leadership. Career validates self-worth. Growth involves inner confidence.",
+        "Virgo": "Virgo in the 10th serves with precision and humility. Overwork hides self-doubt. Growth lies in owning value.",
+        "Libra": "Libra in the 10th harmonizes through diplomacy. Career seeks beauty or fairness. Growth involves bold choices.",
+        "Scorpio": "Scorpio here seeks power and influence. Public life feels intense. Growth lies in transparent leadership.",
+        "Sagittarius": "Sagittarius in the 10th teaches, leads, or explores. Career reflects beliefs. Growth means aligning action with wisdom.",
+        "Capricorn": "Capricorn here is goal-oriented and structured. Career defines identity. Growth means softening the fear of failure.",
+        "Aquarius": "Aquarius in the 10th innovates publicly. Career may be unconventional. Growth involves emotional investment.",
+        "Pisces": "Pisces here dreams in career. Calling may be spiritual or artistic. Growth lies in anchoring vision with structure."
+    },
+    "11th House": {
+        "Aries": "Aries in the 11th leads in community. Friends are challenges or competitors. Growth lies in cooperation.",
+        "Taurus": "Taurus here stabilizes social circles. Loyalty is valued. Growth means allowing evolution in friendship.",
+        "Gemini": "Gemini in the 11th connects through conversation and ideas. Groups stimulate. Growth comes through meaningful connection.",
+        "Cancer": "Cancer here nurtures friends like family. Social life may reflect emotional needs. Growth lies in boundaries.",
+        "Leo": "Leo in the 11th shines in groups and leads with heart. Needs recognition. Growth comes through collective service.",
+        "Virgo": "Virgo in the 11th serves the collective with detail and care. Friends are chosen critically. Growth lies in openness.",
+        "Libra": "Libra here creates harmony in groups. Seeks fair connection. Growth involves deeper authenticity.",
+        "Scorpio": "Scorpio in the 11th bonds deeply but selectively. Trust issues may limit community. Growth lies in emotional risk.",
+        "Sagittarius": "Sagittarius here seeks expansive, inspiring communities. Friends are teachers. Growth involves grounding ideals.",
+        "Capricorn": "Capricorn in the 11th builds legacy through networks. Social status matters. Growth means releasing hierarchy.",
+        "Aquarius": "Aquarius here thrives. Community is future-focused. Growth comes from grounding visions.",
+        "Pisces": "Pisces in the 11th merges with the collective. May lose self in causes. Growth means embodying purpose."
+    },
+    "12th House": {
+        "Aries": "Aries in the 12th hides aggression and action. Shadow holds anger. Healing involves facing inner fire.",
+        "Taurus": "Taurus here represses desire for safety and comfort. The soul seeks stillness. Growth lies in surrendering control.",
+        "Gemini": "Gemini in the 12th hides thoughts and chaos. The mind retreats into fantasy. Growth means expressing inner truth.",
+        "Cancer": "Cancer here hides emotional wounds. The soul craves safety. Healing comes through emotional honesty.",
+        "Leo": "Leo in the 12th hides desire for recognition. The heart feels unseen. Growth involves letting self shine in private.",
+        "Virgo": "Virgo here represses critical thoughts and routines. Overthinking becomes escape. Growth lies in gentleness.",
+        "Libra": "Libra in the 12th hides relational needs. The self dissolves for peace. Growth comes through self-honoring.",
+        "Scorpio": "Scorpio here represses pain and power. Shadow is deep. Healing involves surrender to transformation.",
+        "Sagittarius": "Sagittarius in the 12th escapes through beliefs or fantasy. Meaning becomes avoidance. Growth lies in inner stillness.",
+        "Capricorn": "Capricorn here represses control needs. Shadow fears failure. Growth involves releasing internal pressure.",
+        "Aquarius": "Aquarius in the 12th hides emotional detachment. Avoids belonging. Healing means allowing love.",
+        "Pisces": "Pisces in the 12th dissolves into the collective. Boundaries vanish. Growth means reclaiming the soul’s core."
+    }
+}
+
 
 def get_planet_sign_description(planet, sign):
     """Return psychological description for a planet in a sign."""
     return planet_sign_descriptions.get(planet, {}).get(sign, f"Description for {planet} in {sign} not available.")
+
+
+def get_house_sign_description(house, sign):
+    """Return psychological description for a house cusp in a sign.
+
+    ``house`` can be an integer (1-12) or a string like "1st House".
+    """
+    if isinstance(house, int):
+        ordinal = ["1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th", "9th", "10th", "11th", "12th"]
+        if 1 <= house <= 12:
+            key = f"{ordinal[house-1]} House"
+        else:
+            return f"Description for house {house} in {sign} not available."
+    else:
+        key = str(house)
+    return house_sign_descriptions.get(key, {}).get(sign, f"Description for {key} in {sign} not available.")


### PR DESCRIPTION
## Summary
- enrich `psych_descriptions` with house cusp interpretations by sign
- expose `get_house_sign_description` helper
- include psychological descriptions for houses in chart generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68401a87c47c832b9372553a39849458